### PR TITLE
Adding declaration of UP_LEFT, UP_RIGHT, DOWN_LEFT, DOWN_RIGHT

### DIFF
--- a/SourceCode/Joystick.h
+++ b/SourceCode/Joystick.h
@@ -110,8 +110,12 @@ typedef struct {
 // Custom button mapping, only provide one combination per enum type
 typedef enum {
 	UP,
+	UP_RIGHT,
+	UP_LEFT,
 	UP_A,
 	DOWN,
+	DOWN_RIGHT,
+	DOWN_LEFT,
 	LEFT,
 	RIGHT,
 	RIGHT_A,


### PR DESCRIPTION
Undeclared error when trying to 'make' ShinyFiveRegi.hex. This was because UP_LEFT, UP_RIGHT, DOWN_LEFT and DOWN_RIGHT were undeclared in Joystick.h. I have added those declarations in this commit. 
