### PR TITLE
More Consistant Soft Resets

### DIFF
--- a/SourceCode/Bots/Auto3DaySkipper/Commands.h
+++ b/SourceCode/Bots/Auto3DaySkipper/Commands.h
@@ -137,7 +137,7 @@ static const Command m_command[] PROGMEM = {
 	{A, 1},			// Comfirm close game
 	{NOTHING, 120},
 	{A, 1},			// Choose game
-	{NOTHING, 50},
+	{NOTHING, 150},
 	{A, 1},			// Pick User
 	{NOTHING, 820},
 	{A, 1},			// Enter game

--- a/SourceCode/Bots/PurpleBeamFinder/Commands.h
+++ b/SourceCode/Bots/PurpleBeamFinder/Commands.h
@@ -34,7 +34,7 @@ static const Command m_command[] PROGMEM = {
 	{A, 1},			// Comfirm close game
 	{NOTHING, 120},
 	{A, 1},			// Choose game
-	{NOTHING, 50},
+	{NOTHING, 150},
 	{A, 1},			// Pick User
 	{NOTHING, 820},
 	{A, 1},			// Enter game


### PR DESCRIPTION
I've noticed a problem with the soft resets in some of the programs and my Switch. Sometimes it would take a bit longer for the Switch to bring up the menu for you to pick the user profile. This would cause the program to get out of sync from the switch. To fix this issue, I changed line 140 on the Auto3DaySkipper program from 50 to 150 and line 37 on the PurpleBeamFinder program from 50 to 150. This adds a small bit of time for the profile selector to come up and select the profile I'm using. 

This adds a small bit of time to the overall performance of the program, but it makes it more consistent. I haven't had a need to use all of the programs in the AutoController program, so I'm not sure if this fix can apply to anything other than these 2.