### PR TITLE
Talk to Lotom slowly in AutoLoto

### DIFF
--- a/SourceCode/Bots/AutoLoto/AutoLoto.c
+++ b/SourceCode/Bots/AutoLoto/AutoLoto.c
@@ -224,7 +224,7 @@ void GetNextReport(USB_JoystickReport_Input_t* const ReportData) {
 				{
 					// back to game and loto
 					commandIndex = 50;
-					m_endIndex = 62;
+					m_endIndex = 64;
 					
 					m_sequence = 0;
 					m_skip++;

--- a/SourceCode/Bots/AutoLoto/Commands.h
+++ b/SourceCode/Bots/AutoLoto/Commands.h
@@ -85,12 +85,14 @@ static const Command m_command[] PROGMEM = {
 	{HOME, 5},
 	{NOTHING, 120},
 	
-	//----------Loto [56,62]----------
+	//----------Loto [56,64]----------
 	{A, 60},		// Talk
 	{B, 40},
 	{DPAD_DOWN, 4},
-	{A_SPAM, 50},	// Try Loto-ID
-	{B_SPAM, 200},
+	{A, 90},    // Try Loto-ID
+	{B, 60},
+	{A, 50},
+	{B, 50},
 	{A_SPAM, 50},	// Yes
 	{B_SPAM, 1260},
 };


### PR DESCRIPTION
My game language is Traditional Chinese (CHT), and there is a problem when running AutoLoto.

When talking with Lotom, the action is "Start to Talk"> "Try Loto-ID"> "No"> "Restart to Talk"> "Quit", waiting for a few seconds will start to skip 1 frame and repeat it. I recorded a video to show the problem, you can view it at https://youtu.be/KtRkOSLy1FM.

I think the reason is in CHT the text is shorter than English, and the program will push "B" when Lotom ask player to confirm Loto-ID, and push "A" and "B" a few second, that why player will talk to Lotom again.

I think it is difficult to get a appropriate duration of "A_SPAM" and "B_SPAM" in different language, so I update AutoLoto to only push "A" & "B" four times between "Try Loto-ID" & "Yes". This should be avoided the  same problem occurs in other language. In fact, this change has not been tested in other languages, or we need more tests to confirm it. 